### PR TITLE
Git: Sign commits

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -1,10 +1,13 @@
 [user]
 	email = 
 	name = Daniel A.C. Martin
+	signingkey = 
 [url "https://"]
 	insteadOf = git://
 [core]
 	editor = vim
+[commit]
+	gpgsign = true
 [push]
 	default = simple
 [pull]


### PR DESCRIPTION
This will require the user to provide there signing key after
installation the same way they must provide their e-mail address.